### PR TITLE
Add HTML dashboard generator module

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 Political Party Kit is a modular toolkit for political organizations. It supports internal organization, member management, campaigns, events, communication, and data analysis. Neutral, reusable, and extensible – currently a work in progress.
 
+## Dashboard
+
+Erstelle eine übersichtliche HTML-Dashboard-Seite, über die einzelne Module des Toolkits gestartet
+oder dokumentiert werden können:
+
+```bash
+python -m political_party_kit.dashboard --open
+```
+
+Der Befehl erzeugt eine Datei `dashboard.html` (standardmäßig im aktuellen Ordner) und öffnet sie
+bei Bedarf direkt im Browser. Die Seite listet alle verfügbaren Module auf und zeigt jeweils den
+zugehörigen Startbefehl sowie einen Link zur Dokumentation an.
+
 ## Meeting minutes module
 
 The `political_party_kit.meeting_minutes` package bundles a Whisper + GPT powered workflow for producing structured meeting minutes from audio recordings.  It offers a Python API as well as a CLI entry point.

--- a/political_party_kit/dashboard/__init__.py
+++ b/political_party_kit/dashboard/__init__.py
@@ -1,0 +1,209 @@
+"""Dashboard rendering helpers for the political party kit."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+@dataclass(slots=True)
+class ModuleEntry:
+    """Beschreibung eines Moduls für die Dashboard-Seite."""
+
+    name: str
+    description: str
+    command: str
+    documentation: str | None = None
+
+
+def default_modules() -> list[ModuleEntry]:
+    """Return the built-in modules that can be launched from the dashboard."""
+
+    return [
+        ModuleEntry(
+            name="Sitzungsprotokolle",
+            description=(
+                "Erstellt aus Audioaufnahmen automatisch strukturierte Sitzungsprotokolle "
+                "mithilfe von Whisper und GPT."
+            ),
+            command="python -m political_party_kit.meeting_minutes",
+            documentation="README.md#meeting-minutes-module",
+        ),
+    ]
+
+
+def render_dashboard(modules: Sequence[ModuleEntry] | None = None) -> str:
+    """Render the dashboard HTML for the given modules."""
+
+    modules = list(modules or default_modules())
+    module_cards = "\n".join(
+        _render_card(
+            title=module.name,
+            description=module.description,
+            command=module.command,
+            documentation=module.documentation,
+        )
+        for module in modules
+    )
+    return f"""
+<!DOCTYPE html>
+<html lang=\"de\">
+  <head>
+    <meta charset=\"utf-8\">
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+    <title>Political Party Kit – Dashboard</title>
+    <style>
+      :root {{
+        color-scheme: light dark;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif;
+        background: #f6f7fb;
+        color: #1c1c1c;
+      }}
+      body {{
+        margin: 0;
+        padding: 2rem 1.5rem 4rem;
+        background: linear-gradient(135deg, #f6f7fb 0%, #e5e9ff 100%);
+      }}
+      h1 {{
+        text-align: center;
+        margin-bottom: 0.5rem;
+      }}
+      p.lead {{
+        text-align: center;
+        margin-top: 0;
+        margin-bottom: 2rem;
+        color: #444;
+        max-width: 48rem;
+        margin-left: auto;
+        margin-right: auto;
+      }}
+      main {{
+        display: grid;
+        gap: 1.5rem;
+        max-width: 72rem;
+        margin: 0 auto;
+        grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+      }}
+      article {{
+        background: white;
+        border-radius: 1rem;
+        padding: 1.5rem;
+        box-shadow: 0 20px 45px rgba(41, 51, 76, 0.15);
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+      }}
+      article h2 {{
+        margin: 0;
+        font-size: 1.4rem;
+      }}
+      article p {{
+        margin: 0;
+        flex-grow: 1;
+        line-height: 1.5;
+      }}
+      .actions {{
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.75rem;
+      }}
+      .actions a, .actions code {{
+        font-size: 0.95rem;
+      }}
+      a.button {{
+        background: #1c4ed8;
+        color: white;
+        text-decoration: none;
+        padding: 0.6rem 1rem;
+        border-radius: 999px;
+        font-weight: 600;
+        transition: background 0.15s ease-in-out, transform 0.15s ease-in-out;
+      }}
+      a.button:hover {{
+        background: #173da8;
+        transform: translateY(-1px);
+      }}
+      code {{
+        background: rgba(28, 78, 216, 0.08);
+        color: #0f1f4b;
+        padding: 0.4rem 0.6rem;
+        border-radius: 0.5rem;
+        display: inline-flex;
+        align-items: center;
+      }}
+      footer {{
+        text-align: center;
+        margin-top: 3rem;
+        color: #555;
+        font-size: 0.9rem;
+      }}
+      @media (prefers-color-scheme: dark) {{
+        :root {{
+          background: #111827;
+          color: #f9fafb;
+        }}
+        body {{
+          background: radial-gradient(circle at top, #1f2937 0%, #0f172a 70%);
+        }}
+        article {{
+          background: rgba(17, 24, 39, 0.95);
+          box-shadow: 0 20px 45px rgba(7, 11, 19, 0.35);
+        }}
+        article p {{
+          color: #e5e7eb;
+        }}
+        a.button {{
+          background: #2563eb;
+        }}
+        a.button:hover {{
+          background: #1d4ed8;
+        }}
+        code {{
+          background: rgba(37, 99, 235, 0.25);
+          color: #bfdbfe;
+        }}
+        footer {{
+          color: #9ca3af;
+        }}
+      }}
+    </style>
+  </head>
+  <body>
+    <h1>Political Party Kit</h1>
+    <p class=\"lead\">
+      Zentrale Anlaufstelle für alle Module des Toolkits. Wähle ein Modul aus, um direkt
+      in den jeweiligen Workflow zu starten.
+    </p>
+    <main>
+      {module_cards}
+    </main>
+    <footer>
+      Weitere Module lassen sich problemlos ergänzen, indem sie in der Konfiguration des Dashboards registriert werden.
+    </footer>
+  </body>
+</html>
+"""
+
+
+def _render_card(*, title: str, description: str, command: str, documentation: str | None) -> str:
+    doc_link = (
+        f'<a class="button" href="{documentation}">Dokumentation</a>' if documentation else ""
+    )
+    command_html = f"<code>{command}</code>"
+    actions = " ".join(filter(None, [doc_link, command_html]))
+    return f"""
+      <article>
+        <h2>{title}</h2>
+        <p>{description}</p>
+        <div class=\"actions\">{actions}</div>
+      </article>
+    """
+
+
+def write_dashboard(output: str | Path, modules: Iterable[ModuleEntry] | None = None) -> Path:
+    """Write the dashboard HTML file and return the resulting path."""
+
+    target = Path(output).expanduser().resolve()
+    target.write_text(render_dashboard(list(modules) if modules else None), encoding="utf-8")
+    return target

--- a/political_party_kit/dashboard/__main__.py
+++ b/political_party_kit/dashboard/__main__.py
@@ -1,0 +1,42 @@
+"""CLI to generate the HTML dashboard page."""
+
+from __future__ import annotations
+
+import argparse
+import webbrowser
+from pathlib import Path
+
+from . import ModuleEntry, default_modules, render_dashboard, write_dashboard
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Erstellt die Dashboard-Übersicht als HTML-Datei")
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="dashboard.html",
+        help="Zieldatei für das Dashboard (Standard: dashboard.html im aktuellen Ordner)",
+    )
+    parser.add_argument(
+        "--open",
+        action="store_true",
+        help="Nach dem Erstellen automatisch im Standardbrowser öffnen",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    target = write_dashboard(args.output, default_modules())
+    print(f"Dashboard gespeichert unter: {target}")
+
+    if args.open:
+        webbrowser.open(target.as_uri())
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a dashboard package that renders an HTML overview of available modules
- expose a CLI entry point for generating and optionally opening the dashboard
- document how to create the dashboard in the README

## Testing
- python -m political_party_kit.dashboard --output test_dashboard.html


------
https://chatgpt.com/codex/tasks/task_e_68dd3e3eba3483258c2638e0209a6726